### PR TITLE
dom.fromString: Fix and test additional tags for IE9

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -89,16 +89,21 @@ export function contains(parent: Element, node: Node): boolean {
 
 // Tag trees for element creation, used by fromString
 const tagWrap: {[key: string]: any} = {
-	option: ['select'],
-	tbody: ['table'],
-	thead: ['table'],
-	tfoot: ['table'],
-	tr: ['table', 'tbody'],
-	td: ['table', 'tbody', 'tr'],
-	th: ['table', 'thead', 'tr'],
-	caption: ['table'],
-	colgroup: ['table'],
-	col: ['table', 'colgroup']
+	caption: [ 'table' ],
+	col: [ 'table', 'colgroup' ],
+	colgroup: [ 'table' ],
+	optgroup: [ 'select' ],
+	option: [ 'select' ],
+	rp: [ 'ruby' ],
+	rt: [ 'ruby' ],
+	rtc: [ 'ruby' ],
+	source: [ 'audio' ],
+	tbody: [ 'table' ],
+	td: [ 'table', 'tbody', 'tr' ],
+	tfoot: [ 'table' ],
+	th: [ 'table', 'thead', 'tr' ],
+	thead: [ 'table' ],
+	tr: [ 'table', 'tbody' ]
 };
 
 for (const param in tagWrap) {

--- a/tests/unit/dom.ts
+++ b/tests/unit/dom.ts
@@ -320,10 +320,32 @@ registerSuite({
 	},
 
 	fromString: (function () {
-		function createTagTest(tagName: string) {
+		const tags = [
+			'caption',
+			'col',
+			'colgroup',
+			'optgroup',
+			'option',
+			'rp',
+			'rt',
+			'rtc',
+			'ruby',
+			'tbody',
+			'td',
+			'tfoot',
+			'th',
+			'thead',
+			'tr'
+		];
+
+		const selfClosingTags = [
+			'source'
+		];
+
+		function createTagTest(tagName: string, selfClosing?: boolean) {
 			return function () {
 				// Single
-				let html = '<' + tagName + '></' + tagName + '>';
+				let html = '<' + tagName + '>' + (selfClosing ? '' : '</' + tagName + '>');
 				let fragment = dom.fromString(html);
 				assert.strictEqual(fragment.firstChild.nodeName, tagName.toUpperCase());
 
@@ -336,7 +358,7 @@ registerSuite({
 			};
 		}
 
-		return {
+		var tests: any = {
 			'returns document fragment for single node'() {
 				let result = dom.fromString('<div></div>');
 				assert.strictEqual(result.firstChild.nodeName, 'DIV');
@@ -369,20 +391,17 @@ registerSuite({
 					assert.strictEqual(fragment.childNodes[i].nodeName,
 						parent.childNodes[i].nodeName);
 				}
-			},
-
-			'<option> is created successfully and returned unwrapped': createTagTest('option'),
-			'<tbody> is created successfully and returned unwrapped': createTagTest('tbody'),
-			'<thead> is created successfully and returned unwrapped': createTagTest('thead'),
-			'<tfoot> is created successfully and returned unwrapped': createTagTest('tfoot'),
-			'<th> is created successfully and returned unwrapped': createTagTest('th'),
-			'<td> is created successfully and returned unwrapped': createTagTest('td'),
-			'<legend> is created successfully and returned unwrapped': createTagTest('legend'),
-			'<caption> is created successfully and returned unwrapped': createTagTest('caption'),
-			'<colgroup> is created successfully and returned unwrapped': createTagTest('colgroup'),
-			'<col> is created successfully and returned unwrapped': createTagTest('col'),
-			'<li> is created successfully and returned unwrapped': createTagTest('li')
+			}
 		};
+
+		for (let tag of tags) {
+			tests['<' + tag + '> is created successfully and returned unwrapped'] = createTagTest(tag);
+		}
+		for (let tag of selfClosingTags) {
+			tests['<' + tag + '> is created successfully and returned unwrapped'] = createTagTest(tag, true);
+		}
+
+		return tests;
 	})(),
 
 	place: (function () {


### PR DESCRIPTION
fromString needs to wrap these tags to function properly in IE9.

I experimented with adding a full battery of tags to test `fromString` with, based on the list of `createElement` overrides in dom.generated.d.ts and the list of elements in MDN (skipping obsolete ones).

The result I came out with was that most browsers fared fine, but IE9 had issues with `optgroup`, `source`, and a few `ruby`-related tags.  I've added wrapping information and tests for those so they now pass.