### PR TITLE
Added a test for delegate selector matching

### DIFF
--- a/tests/unit/delegate.ts
+++ b/tests/unit/delegate.ts
@@ -139,6 +139,22 @@ registerSuite({
 		assert.strictEqual(called, 0);
 	},
 
+	'CSS selector must not match ancestors of delegated target'() {
+		let called = 0;
+		let parent = document.createElement('span');
+		let child = document.createElement('button');
+
+		handles.push(delegate(parent, 'div', 'click', function () {
+			called++;
+		}));
+
+		parent.appendChild(child);
+		container.appendChild(parent);
+
+		child.click();
+		assert.strictEqual(called, 0);
+	},
+
 	'Comma-separated selector handling'() {
 		let called = 0;
 		let buttonOne = document.createElement('button');


### PR DESCRIPTION
This test covers a situation not explicitly covered by other tests.

Consider
```html
<div>
  <span>
    <button></button>
  </span>
</div>
```
```javascript
delegate(span, 'div', 'click', function () {});
button.click();
```

The event handler should not be called, since the `div` is not between the `button` (the event target) and the `span` (the delegated target).