### PR TITLE
Improved delegate() selector matching performance

### DIFF
--- a/src/delegate.ts
+++ b/src/delegate.ts
@@ -28,12 +28,13 @@ export default function delegate(target: HTMLElement, selector: string, type: st
 export default function delegate(target: HTMLElement, selector: string, type: string[], listener: (event: UIEvent) => void): Handle;
 export default function delegate(target: HTMLElement, selector: string, type: any, listener: (event: UIEvent) => void): Handle {
 	function matches(element: HTMLElement, selector: string) {
-		// Search in parents of the given element as well,
+		// Search in ancestors of the given element as well,
 		// since the event could have bubbled into an element matching the selector
+		// Once the target is reached, stop going up the ancestor chain (for performance)
 
 		// TS7017
 		while (!(<any> element)[matchesMethod](selector)) {
-			if (!element.parentNode || !(<any> element.parentNode)[matchesMethod]) {
+			if (!element.parentNode || !(<any> element.parentNode)[matchesMethod] || element === target) {
 				return null;
 			}
 			element = <HTMLElement> element.parentNode;


### PR DESCRIPTION
`matches()` stops searching the event target's ancestry chain after the delegated target has been reached.

This makes no difference to the function's return value (thanks to the delegated target's id being prefixed to the selectors), but it does improve performance, since the delegated target's ancestors are simply ignored instead of being evaluated (and rejected).