### PR TITLE
Remove unnecessary webkitMatchesSelector check.

### DIFF
--- a/src/has.ts
+++ b/src/has.ts
@@ -6,9 +6,6 @@ add('dom-element-matches', function () {
 	if (typeof (<any> node).matches === 'function') {
 		return 'matches';
 	}
-	if (typeof node.webkitMatchesSelector === 'function') {
-		return 'webkitMatchesSelector';
-	}
 	if (typeof node.msMatchesSelector === 'function') {
 		return 'msMatchesSelector';
 	}


### PR DESCRIPTION
Resolves #26. Latest Opera and our supported versions of Chrome and Safari use `Element#matches`. I wanted to test earlier versions of Opera to discern the earliest version supporting `Element#matches`, but have experienced some difficulty finding the older install packages.