### PR TITLE
- Fix #32: added check for webbitMatchesSelector to support Android n…

### DIFF
--- a/src/has.ts
+++ b/src/has.ts
@@ -9,6 +9,9 @@ add('dom-element-matches', function () {
 	if (typeof node.msMatchesSelector === 'function') {
 		return 'msMatchesSelector';
 	}
+	if (typeof node.webkitMatchesSelector === 'function') {
+		return 'webkitMatchesSelector';
+	}
 });
 
 export { cache, add, default } from 'dojo-core/has';

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -21,9 +21,9 @@ export var capabilities = {
 export const environments = [
 	{ browserName: 'internet explorer', version: ['9', '10', '11'], platform: 'WINDOWS' },
 	{ browserName: 'firefox', platform: 'WINDOWS' },
-	{ browserName: 'chrome', platform: 'WINDOWS' }/*,
-	{ browserName: 'safari', version: '9', platform: 'MAC' }
-	{ browserName: 'android', device: 'Samsung Galaxy S5', platform: 'ANDROID'}*/
+	{ browserName: 'chrome', platform: 'WINDOWS' },
+	// { browserName: 'safari', version: '9', platform: 'MAC' },
+	{ browserName: 'android', device: 'Samsung Galaxy S5', platform: 'ANDROID'}
 ];
 
 // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service

--- a/tests/unit/form.ts
+++ b/tests/unit/form.ts
@@ -170,6 +170,13 @@ registerSuite({
 			function runTest() {
 				const options = testForm['select'].options;
 
+				// Set multiple values
+				form.fromObject(testForm, { select: [ 'bar', 'baz' ] });
+				assert.isFalse(options[0].selected);
+				assert.isTrue(options[1].selected);
+				assert.isTrue(options[2].selected);
+				assert.isFalse(options[3].selected);
+
 				// Set single value
 				form.fromObject(testForm, { select: 'foo' });
 				assert.isTrue(options[0].selected);
@@ -177,12 +184,6 @@ registerSuite({
 				assert.isFalse(options[2].selected);
 				assert.isFalse(options[3].selected);
 
-				// Set multiple values
-				form.fromObject(testForm, { select: [ 'bar', 'baz' ] });
-				assert.isFalse(options[0].selected);
-				assert.isTrue(options[1].selected);
-				assert.isTrue(options[2].selected);
-				assert.isFalse(options[3].selected);
 			}
 
 			return {


### PR DESCRIPTION
…ative browser for Android <5

- reenabled tests for Android browser
- reordered the tests in the runTests() function in form -> "select-multiple" to work around odd behavior on BrowserStack and SauceLabs which would fail tests that pass when using an emulator