### PR TITLE
Added tests for creating wrapped tags with dom.create()

### DIFF
--- a/tests/unit/dom.ts
+++ b/tests/unit/dom.ts
@@ -168,6 +168,10 @@ registerSuite({
 				dom.create('option', { value: 'bar' }, [ 'bar' ])
 			]);
 			assert.strictEqual(select.value, 'bar');
+		},
+		'created children that need to be created in a specific context'() {
+			const result = dom.create('td');
+			assert.strictEqual(result.outerHTML, '<td></td>');
 		}
 	},
 

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -1,3 +1,4 @@
-/// <reference path="../node_modules/dojo-core/typings/dojo-core/dojo-core-2.0.0-alpha.3.d.ts"/>
+/// <reference path="../node_modules/dojo-core/typings/dojo-core/dojo-core-2.0.0-pre.d.ts"/>
 /// <reference path="../node_modules/dojo-loader/typings/dojo-loader/dojo-loader-2.0.0-beta.2.d.ts" />
 /// <reference path="../tests/typings/node/node.d.ts" />
+/// <reference path="../node_modules/dojo-core/typings/symbol-shim/symbol-shim.d.ts"/>


### PR DESCRIPTION
Added test to ensure that dom.create() will create nodes that need to be created in the context of another element (e.g. table cells).

Addresses issue #42