### PR TITLE
Update to allow testing against Sauce Labs and Browserstack

### DIFF
--- a/tests/intern-saucelabs.ts
+++ b/tests/intern-saucelabs.ts
@@ -2,7 +2,8 @@ export * from './intern';
 
 export const environments = [
 	{ browserName: 'internet explorer', version: ['9.0', '10.0', '11.0'], platform: 'Windows 7' },
-	/* { browserName: 'microsoftedge', platform: 'Windows 10' }, */
+	/* Intern 3.0.6 sometimes works on Edge */
+	{ browserName: 'microsoftedge', platform: 'Windows 10' },
 	{ browserName: 'firefox', platform: 'Windows 10' },
 	{ browserName: 'chrome', platform: 'Windows 10' },
 	/* Still appear to be issues on Safari on SauceLabs */


### PR DESCRIPTION
updated Gruntfile and intern configs to allow both Saucelabs and BrowserStack to be used via different grunt tasks