### PR TITLE
Remove node_modules cache from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ env:
   - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
   - BROWSERSTACK_USERNAME: dtktestaccount1
   - BROWSERSTACK_ACCESS_KEY: mG2qbEFJCZY2qLsM7yfx
-cache:
-  directories:
-  - node_modules
 install:
 - npm install grunt-cli
 - npm install


### PR DESCRIPTION
<!--
Thank you for Contributing to Dojo 2.

Please make sure you have read our Contributing Guidelines
available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
before submitting a PR.

-->

**Type:** bug

**Description:** 

Remove node_modules cache from .travis.yml

**Related Issue:** #75

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [x] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged