### PR TITLE
Update Dojo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dojo-dom",
   "version": "2.0.0-pre",
   "description": "DOM Utilities for Dojo 2",
-  "homepage": "http://dojotoolkit.org",
+  "homepage": "https://dojo.io",
   "bugs": {
     "url": "https://github.com/dojo/dom/issues"
   },


### PR DESCRIPTION
Updated the homepage URL in package.json to point to https://dojo.io.

Refs: dojo/meta#166